### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,27 @@
+name: Deploy static content to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v1
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # mywebsite
+
+This repository contains a very simple website. To view it locally, run:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then open your browser to `http://localhost:8000`.
+
+## Deploying to GitHub Pages
+
+1. In your repository settings, open the **Pages** section.
+2. Set **Build and deployment** source to **GitHub Actions**.
+3. After pushing to the `main` branch, the included workflow will automatically deploy the site.
+4. Visit `https://<your-username>.github.io/<your-repo>/` to see it live.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>My Website</title>
+</head>
+<body>
+    Awesome
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add GitHub Pages workflow
- skip Jekyll processing
- document how to enable GitHub Pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684703f4174483338a18c4de59c2a7a0